### PR TITLE
Addresses alias resolution in commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ alias envstack-set='source <(envstack "$1" --export)';
 
 #### cmd
 ```cmd
-doskey envstack-set=for /f "usebackq" %%i in (`envstack --export $*`) do %%i
+doskey envstack-set=for /f "usebackq" %i in (`envstack --export $*`) do %%i
 ```
 
 Then you can set the environment stack in your shell with the `envstack-set`
@@ -237,7 +237,7 @@ alias envstack-clear='source <(envstack "$1" --clear)';
 
 #### cmd
 ```cmd
-doskey envstack-clear=for /f "usebackq" %%i in (`envstack --clear $*`) do %%i
+doskey envstack-clear=for /f "usebackq" %i in (`envstack --clear $*`) do %%i
 ```
 
 Create a function for convenience that does both in one command:

--- a/README.md
+++ b/README.md
@@ -161,8 +161,8 @@ To init the environment stack, use the `init` function:
 'bar'
 ```
 
-Alternatively, `envstack.getenv` uses the default environment stack `stack` and
-can be a drop-in replacement for `os.getenv` 
+Alternatively, `envstack.getenv` can be a drop-in replacement for `os.getenv`
+for the default environment stack:
 
 ```python
 >>> import envstack

--- a/lib/envstack/__init__.py
+++ b/lib/envstack/__init__.py
@@ -34,7 +34,7 @@ Stacked environment variable management system.
 """
 
 __prog__ = "envstack"
-__version__ = "0.5.3"
+__version__ = "0.5.4"
 
 from envstack.env import Env
 from envstack.env import getenv, init, load_file

--- a/lib/envstack/cli.py
+++ b/lib/envstack/cli.py
@@ -145,7 +145,9 @@ def main():
         elif command:
             return run_command(command, args.namespace)
         else:
-            env = load_environ(args.namespace, platform=args.platform, includes=True)
+            env = load_environ(
+                args.namespace, environ=None, platform=args.platform, includes=True
+            )
             for k, v in env.items():
                 print(f"{k}={v}")
 

--- a/lib/envstack/cli.py
+++ b/lib/envstack/cli.py
@@ -143,7 +143,7 @@ def main():
         elif args.export:
             print(export(args.namespace, config.SHELL))
         elif command:
-            return run_command(args.namespace, command)
+            return run_command(command, args.namespace)
         else:
             env = load_environ(args.namespace, platform=args.platform, includes=True)
             for k, v in env.items():

--- a/lib/envstack/env.py
+++ b/lib/envstack/env.py
@@ -528,7 +528,7 @@ def export(name, shell="bash", resolve=False, scope=None, clear=False):
     for k, v in env.items():
         if resolve:
             v = expandvars(v, env, recursive=False)
-        if shell == "bash" or shell == "sh":
+        if shell in ["bash", "sh", "zsh"]:
             if clear:
                 expList.append(f"unset {k}")
             else:
@@ -548,6 +548,8 @@ def export(name, shell="bash", resolve=False, scope=None, clear=False):
                 expList.append(f"Remove-Item Env:{k}")
             else:
                 expList.append(f'$env:{k}="{v}"')
+        elif shell == "unknown":
+            raise Exception("unknown shell")
     expList.sort()
     exp = "\n".join(expList)
     return exp

--- a/lib/envstack/env.py
+++ b/lib/envstack/env.py
@@ -645,7 +645,7 @@ def load_file(path):
     return data
 
 
-def merge(env, other):
+def merge(env, other, strict=False):
     """Merges values from other into env. For example, to merge values from
     the local environment into an env instance:
 
@@ -657,12 +657,23 @@ def merge(env, other):
 
     :param env: source env
     :param other: env to merge
+    :param strict: env value takes precedence (default: False)
     :returns: merged env
     """
     merged = env.copy()
-    for key in merged:
+    for key, value in merged.items():
         if key in other:
-            merged[key] = other.get(key)
+            # append value from other
+            if os.pathsep in str(value):
+                value = re.sub(
+                    r"\${(\w+)}",
+                    lambda match: other.get(match.group(1), match.group(0)),
+                    value,
+                )
+            # replace value from other
+            elif not strict:
+                value = other.get(key)
+            merged[key] = value
     return merged
 
 

--- a/lib/envstack/env.py
+++ b/lib/envstack/env.py
@@ -662,18 +662,19 @@ def merge(env, other, strict=False):
     """
     merged = env.copy()
     for key, value in merged.items():
+        var = "${%s}" % key
         if key in other:
-            # append value from other
-            if os.pathsep in str(value):
+            if var in str(value):
                 value = re.sub(
                     r"\${(\w+)}",
                     lambda match: other.get(match.group(1), match.group(0)),
                     value,
                 )
-            # replace value from other
             elif not strict:
                 value = other.get(key)
-            merged[key] = value
+        else:
+            value = value.replace(var, "")
+        merged[key] = value
     return merged
 
 

--- a/lib/envstack/env.py
+++ b/lib/envstack/env.py
@@ -179,7 +179,7 @@ class EnvVar(string.Template, str):
 
     def value(self):
         """Returns EnvVar value."""
-        return safe_eval(self.template)
+        return re.sub(r"(?<!\b[A-Za-z]):", os.pathsep, safe_eval(self.template))
 
     def vars(self):
         """Returns a list of embedded, named variables, e.g.: ::

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ class PostInstallCommand(install):
 
 setup(
     name="envstack",
-    version="0.5.3",
+    version="0.5.4",
     description="Stacked environment variable management system.",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/stack.env
+++ b/stack.env
@@ -1,6 +1,11 @@
-# stack.env is the default envstack file
+# Stacked environment variable management system.
 #
-# https://github.com/rsgalloway/envstack
+# Environment variables are declared in namespaced .env files using yaml syntax.
+# The default stack declares env variables in stack.env files.
+# Create any new stack by creating new .env files, e.g. to create a new stack
+# called "thing", just create thing.env files in any given context.
+#
+# $ pip install envstack
 
 all: &default
   ENV: prod
@@ -8,10 +13,10 @@ all: &default
   LOG_LEVEL: INFO
   DEFAULT_ENV_DIR: ${DEPLOY_ROOT}/env
   DEPLOY_ROOT: ${ROOT}/${ENV}
-  # BIN: ${DEPLOY_ROOT}/bin
-  # LIB: ${DEPLOY_ROOT}/lib/python
-  # PATH: "${BIN}:${PATH}"
-  # PYTHONPATH: "${LIB}:${PYTHONPATH}"
+  BIN: ${DEPLOY_ROOT}/bin
+  LIB: ${DEPLOY_ROOT}/lib/python
+  PATH: "${BIN}:${PATH}"
+  PYTHONPATH: "${LIB}:${PYTHONPATH}"
 
 darwin:
   <<: *default

--- a/stack.env
+++ b/stack.env
@@ -11,7 +11,7 @@ all: &default
   # BIN: ${DEPLOY_ROOT}/bin
   # LIB: ${DEPLOY_ROOT}/lib/python
   # PATH: "${BIN}:${PATH}"
-  # PYTHONPATH: "${LIB}/python:${PYTHONPATH}"
+  # PYTHONPATH: "${LIB}:${PYTHONPATH}"
 
 darwin:
   <<: *default


### PR DESCRIPTION
- addresses alias resolution in commands (fixes issue #1 )
- replace colons in value declarations with os.pathsep (platform agnostic)
- do not merge with os.environ when printing values to stdout (default 'envstack' command)
- bumps version to 0.5.4