### PR TITLE
0.6.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ You can override anything in the environment stack by setting values in the
 local environment first:
 
 ```bash
-$ envstack -- echo \$HELLO
+$ envstack -- echo {HELLO}
 world
-$ HELLO=goodbye envstack -- echo \$HELLO
+$ HELLO=goodbye envstack -- echo {HELLO}
 goodbye
 ```
 
@@ -190,7 +190,7 @@ $ envstack [STACK] -- [COMMAND]
 For example:
 
 ```bash 
-$ envstack -- echo \$HELLO
+$ envstack -- echo {HELLO}
 world
 ```
 

--- a/lib/envstack/__init__.py
+++ b/lib/envstack/__init__.py
@@ -34,6 +34,6 @@ Stacked environment variable management system.
 """
 
 __prog__ = "envstack"
-__version__ = "0.6.1"
+__version__ = "0.6.2"
 
 from envstack.env import Env, getenv, init, load_file

--- a/lib/envstack/wrapper.py
+++ b/lib/envstack/wrapper.py
@@ -233,15 +233,20 @@ def run_command(command, namespace=config.DEFAULT_NAMESPACE):
 
         >>> run_command(['ls', '-l'], 'my-stack')
 
+     - Automatically detects the shell to use based on the config.SHELL value.
+     - Converts {VAR} to $VAR for bash, sh, zsh, and %VAR% for cmd.
+
     :param command: command to run as a list of arguments
     :param namespace: environment stack namespace (default: 'stack')
-    :returns: exit code
+    :returns: command exit code
     """
     logger.setup_stream_handler()
     if config.SHELL in ["bash", "sh", "zsh"]:
-        cmd = ShellWrapper(namespace, shlex.join(command))
+        command = re.sub(r"\{(\w+)\}", r"${\1}", shlex.join(command))
+        cmd = ShellWrapper(namespace, command)
     elif config.SHELL in ["cmd"]:
-        cmd = CmdWrapper(namespace, " ".join(command))
+        command = re.sub(r"\{(\w+)\}", r"%\1%", " ".join(command))
+        cmd = CmdWrapper(namespace, command)
     else:
         cmd = CommandWrapper(namespace, command)
     return cmd.launch()

--- a/lib/envstack/wrapper.py
+++ b/lib/envstack/wrapper.py
@@ -49,6 +49,14 @@ def to_args(cmd):
     return shlex.split(cmd)
 
 
+def shell_join(args):
+    """Joins a list of arguments into a single quoted shell string."""
+    try:
+        return shlex.join(args)
+    except AttributeError:
+        return " ".join(shlex.quote(arg) for arg in args)
+
+
 class Wrapper(object):
     """Wrapper class for executables. Subprocessed with preconfigured environment.
 
@@ -242,7 +250,7 @@ def run_command(command, namespace=config.DEFAULT_NAMESPACE):
     """
     logger.setup_stream_handler()
     if config.SHELL in ["bash", "sh", "zsh"]:
-        command = re.sub(r"\{(\w+)\}", r"${\1}", shlex.join(command))
+        command = re.sub(r"\{(\w+)\}", r"${\1}", shell_join(command))
         cmd = ShellWrapper(namespace, command)
     elif config.SHELL in ["cmd"]:
         command = re.sub(r"\{(\w+)\}", r"%\1%", " ".join(command))

--- a/lib/envstack/wrapper.py
+++ b/lib/envstack/wrapper.py
@@ -250,9 +250,11 @@ def run_command(command, namespace=config.DEFAULT_NAMESPACE):
     """
     logger.setup_stream_handler()
     if config.SHELL in ["bash", "sh", "zsh"]:
+        # convert {VAR} to ${VAR}, e.g. 'echo {VAR}' -> 'echo ${VAR}'
         command = re.sub(r"\{(\w+)\}", r"${\1}", shell_join(command))
         cmd = ShellWrapper(namespace, command)
     elif config.SHELL in ["cmd"]:
+        # convert {VAR} to %VAR%, e.g. 'echo {VAR}' -> 'echo %VAR%'
         command = re.sub(r"\{(\w+)\}", r"%\1%", " ".join(command))
         cmd = CmdWrapper(namespace, command)
     else:

--- a/setup.py
+++ b/setup.py
@@ -81,6 +81,23 @@ setup(
     author="Ryan Galloway",
     author_email="ryan@rsgalloway.com",
     url="http://github.com/rsgalloway/envstack",
+    license="BSD 3-Clause License",
+    classifiers=[
+        # How mature is this project? Common values are
+        #   3 - Alpha
+        #   4 - Beta
+        #   5 - Production/Stable
+        "Development Status :: 4 - Beta",
+        "Intended Audience :: Developers",
+        "Topic :: Software Development :: Libraries",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+    ],
     package_dir={"": "lib"},
     packages=find_packages("lib"),
     entry_points={
@@ -91,6 +108,7 @@ setup(
     install_requires=[
         "PyYAML>=5.1.2",
     ],
+    python_requires=">=3.6",
     data_files=[(".", ["stack.env", "dev.env", "dist.json"])],
     cmdclass={"install": PostInstallCommand},
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ class PostInstallCommand(install):
 
 setup(
     name="envstack",
-    version="0.6.1",
+    version="0.6.2",
     description="Stacked environment variable management system",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
- adds support for env var token substitution in command wrappers
- addresses issue #6 
- adds metadata and Python version reqs to setup.py

```bash
$ envstack -- echo \$HELLO
world
$ envstack -- echo {HELLO}
world
```