### PR TITLE
Updates envstack.init to modify sys.path

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,16 +164,31 @@ $ envstack [STACK] --sources
 To init the environment stack, use the `init` function:
 
 ```python
->>> envstack.init("thing")
->>> os.getenv("FOO")
-'bar'
+>>> envstack.init()
+>>> os.getenv("HELLO")
+'world'
+```
+
+To initialize the "dev" stack:
+
+```python
+>>> envstack.init("dev")
+>>> os.getenv("ENV")
+'dev'
+```
+
+To revert the original environment:
+
+```python
+>>> envstack.revert()
+>>> os.getenv("HELLO")
+>>> 
 ```
 
 Alternatively, `envstack.getenv` can be a drop-in replacement for `os.getenv`
 for the default environment stack:
 
 ```python
->>> import envstack
 >>> envstack.getenv("HELLO")
 'world'
 ```

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ $ envstack [STACK] --sources
 
 ## Python API
 
-To init the environment stack, use the `init` function:
+To initialize the environment stack in Python, use the `init` function:
 
 ```python
 >>> envstack.init()

--- a/lib/envstack/__init__.py
+++ b/lib/envstack/__init__.py
@@ -36,4 +36,4 @@ Stacked environment variable management system.
 __prog__ = "envstack"
 __version__ = "0.6.2"
 
-from envstack.env import Env, getenv, clear, init, load_file
+from envstack.env import Env, getenv, init, load_file, revert, save

--- a/lib/envstack/__init__.py
+++ b/lib/envstack/__init__.py
@@ -34,6 +34,6 @@ Stacked environment variable management system.
 """
 
 __prog__ = "envstack"
-__version__ = "0.6.2"
+__version__ = "0.6.3"
 
 from envstack.env import Env, getenv, init, load_file, revert, save

--- a/lib/envstack/config.py
+++ b/lib/envstack/config.py
@@ -76,14 +76,13 @@ DEFAULT_ENV = {
     "USER": USERNAME,
 }
 
-# default location of envstack files
-# NOTE: the siteconf sitecustomize.py module may override this
+# default location of env stack .env files
 DEFAULT_ENV_DIR = os.getenv(
     "DEFAULT_ENV_DIR",
     {
-        "darwin": "{HOME}/Library/Application Support/envstack",
-        "linux": "{HOME}/.local/envstack",
-        "windows": "C:\\ProgramData\\envstack",
+        "darwin": "{HOME}/Library/Application Support/pipe/{ENV}/env",
+        "linux": "{HOME}/.local/pipe/{ENV}/env",
+        "windows": "C:\\ProgramData\\pipe\\{ENV}\\env",
     }
     .get(PLATFORM)
     .format(**DEFAULT_ENV),

--- a/lib/envstack/env.py
+++ b/lib/envstack/env.py
@@ -605,6 +605,15 @@ def init(name=config.DEFAULT_NAMESPACE):
     """Initializes the environment for a given namespace. Modifies sys.path
     from PYTHONPATH.
 
+        # initialize the default environemnt
+        >>> envstack.init()
+
+        # initialize the dev environment
+        >>> envstack.init('dev')
+
+        # revert to the original environment
+        >>> envstack.revert()
+
     :param name: stack namespace (default stack).
     """
     logger.log.debug("initializing env stack: %s", name)

--- a/lib/envstack/env.py
+++ b/lib/envstack/env.py
@@ -591,13 +591,11 @@ def clear(name=config.DEFAULT_NAMESPACE):
     # remove env stack paths from PYTHONPATH
     for path in util.get_paths_from_var("PYTHONPATH"):
         if path and path in sys.path:
-            logger.log.debug("removing path: %s", path)
             sys.path.remove(path)
 
-    # update sys.path from _OLD_PYTHONPATH
+    # restore sys.path from _OLD_PYTHONPATH
     for path in util.get_paths_from_var("_OLD_PYTHONPATH"):
         if path and path not in sys.path:
-            logger.log.debug("restoring path: %s", path)
             sys.path.insert(0, path)
 
     env = load_environ(name)
@@ -607,7 +605,8 @@ def clear(name=config.DEFAULT_NAMESPACE):
 
 
 def init(name=config.DEFAULT_NAMESPACE):
-    """Initializes the environment for a given namespace.
+    """Initializes the environment for a given namespace. Modifies sys.path
+    from PYTHONPATH.
 
     :param name: stack namespace (default stack).
     """

--- a/lib/envstack/util.py
+++ b/lib/envstack/util.py
@@ -36,6 +36,29 @@ Contains common utility functions and classes.
 import os
 
 
+def dict_diff(dict1, dict2):
+    """
+    Compare two dictionaries and return their differences.
+
+    :param dict1: First dictionary.
+    :param dict2: Second dictionary.
+    :returns: diff dict: 'added', 'removed', 'changed', and 'unchanged'.
+    """
+    added = {k: dict2[k] for k in dict2 if k not in dict1}
+    removed = {k: dict1[k] for k in dict1 if k not in dict2}
+    changed = {
+        k: (dict1[k], dict2[k]) for k in dict1 if k in dict2 and dict1[k] != dict2[k]
+    }
+    unchanged = {k: dict1[k] for k in dict1 if k in dict2 and dict1[k] == dict2[k]}
+
+    return {
+        "added": added,
+        "removed": removed,
+        "changed": changed,
+        "unchanged": unchanged,
+    }
+
+
 def get_paths_from_var(var="PYTHONPATH", pathsep=os.pathsep, reverse=True):
     """Returns a list of paths from a given pathsep separated environment
     variable.

--- a/lib/envstack/util.py
+++ b/lib/envstack/util.py
@@ -30,10 +30,29 @@
 #
 
 __doc__ = """
-Stacked environment variable management system.
+Contains common utility functions and classes.
 """
 
-__prog__ = "envstack"
-__version__ = "0.6.2"
+import os
 
-from envstack.env import Env, getenv, clear, init, load_file
+
+def get_paths_from_var(var="PYTHONPATH", pathsep=os.pathsep, reverse=True):
+    """Returns a list of paths from a given pathsep separated environment
+    variable.
+
+    :param var: The environment variable to get paths from.
+    :param pathsep: The path separator to use.
+    :param reverse: Reverse the order of the paths.
+    :returns: A list of paths.
+    """
+
+    paths = []
+    value = os.environ.get(var)
+
+    if value:
+        paths = value.split(pathsep)
+
+        if reverse:
+            paths.reverse()
+
+    return paths

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ class PostInstallCommand(install):
 
 setup(
     name="envstack",
-    version="0.6.2",
+    version="0.6.3",
     description="Stacked environment variable management system",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Updates `sys.path` from `PYTHONPATH` set in the environment stack. 

- Updates `init()` to modify `sys.path`
- Adds `save` and `revert` functions to save and revert current environment
- Updates `DEFAULT_ENV_DIR` in config to `pipe/{ENV}/env`
- Adds utils module
- Bumps version to 0.6.3
- Addresses issue #8 
