### PR TITLE
Version 0.8.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ HELLO: world
 We can also encrypt the values automatically (base64 by default):
 
 ```bash
-$ envstack --set HELLO:world --encrypt
+$ envstack -s HELLO:world -e
 HELLO: d29ybGQ=
 ```
 
@@ -204,7 +204,7 @@ Add more variables (note that `$` needs to be escaped in bash or else it will
 be evaluated immediately):
 
 ```bash
-$ envstack --set HELLO:world VAR:\${HELLO}
+$ envstack -s HELLO:world VAR:\${HELLO}
 HELLO: world
 VAR: ${HELLO}
 ```
@@ -212,7 +212,7 @@ VAR: ${HELLO}
 To write out to a file use the `-o` option:
 
 ```bash
-$ envstack --set HELLO:world -o hello.env
+$ envstack -s HELLO:world -o hello.env
 ```
 
 ## Creating Stacks
@@ -240,6 +240,13 @@ linux:
   <<: *all
 windows:
   <<: *all
+```
+
+Or using Python:
+
+```python
+>>> env = Env({"FOO": "bar", "BAR": "${FOO}"})
+>>> env.write("foobar.env")
 ```
 
 Get the resolved environment for the `foobar` stack:

--- a/README.md
+++ b/README.md
@@ -184,6 +184,37 @@ $ HELLO=goodbye envstack -- echo {HELLO}
 goodbye
 ```
 
+#### Using the command-line
+
+Here we can set values using the `envstack` command:
+
+```bash
+$ envstack --set HELLO:world
+HELLO: world
+```
+
+We can also encrypt the values automatically (base64 by default):
+
+```bash
+$ envstack --set HELLO:world --encrypt
+HELLO: d29ybGQ=
+```
+
+Add more variables (note that `$` needs to be escaped in bash or else it will
+be evaluated immediately):
+
+```bash
+$ envstack --set HELLO:world VAR:\${HELLO}
+HELLO: world
+VAR: ${HELLO}
+```
+
+To write out to a file use the `-o` option:
+
+```bash
+$ envstack --set HELLO:world -o hello.env
+```
+
 ## Creating Stacks
 
 Several example or starter stacks are available in the [env folder of the

--- a/README.md
+++ b/README.md
@@ -145,8 +145,8 @@ allows you to override the value:
 | Value | Description |
 |---------------------|-------------|
 | value |  'value' |
-| ${VAR:-default} | os.environ.get('VAR', 'default') |
 | ${VAR:=default} | VAR = VAR or 'default' |
+| ${VAR:-default} | os.environ.get('VAR', 'default') |
 | ${VAR:?error message} | if not VAR: raise ValueError() |
 
 Without the expansion modifier, values are set and do not change (but can be

--- a/lib/envstack/__init__.py
+++ b/lib/envstack/__init__.py
@@ -34,6 +34,6 @@ Stacked environment variable management system.
 """
 
 __prog__ = "envstack"
-__version__ = "0.8.3"
+__version__ = "0.8.4"
 
 from envstack.env import clear, init, revert, save  # noqa: F401

--- a/lib/envstack/cli.py
+++ b/lib/envstack/cli.py
@@ -204,7 +204,7 @@ def main():
             data = dict(kv.split(":", 1) for kv in args.set)
 
             if args.encrypt:
-                data = encrypt_environ(data)
+                data = encrypt_environ(data, encrypt=(not args.out))
             if args.export:
                 print(export_env_to_shell(data))
             elif args.out:

--- a/lib/envstack/cli.py
+++ b/lib/envstack/cli.py
@@ -105,6 +105,7 @@ def parse_args():
         help="generate encryption keys",
     )
     bake_group.add_argument(
+        "-e",
         "--encrypt",
         action="store_true",
         help="encrypt the baked environment values",
@@ -128,6 +129,7 @@ def parse_args():
         help="platform to resolve variables for (linux, darwin, windows)",
     )
     parser.add_argument(
+        "-s",
         "--set",
         nargs="*",
         metavar="VAR:VALUE",

--- a/lib/envstack/cli.py
+++ b/lib/envstack/cli.py
@@ -125,6 +125,12 @@ def parse_args():
         help="platform to resolve variables for (linux, darwin, windows)",
     )
     parser.add_argument(
+        "--set",
+        nargs="*",
+        metavar="VAR:VALUE",
+        help="set a key:value pair in the environment",
+    )
+    parser.add_argument(
         "--scope",
         metavar="SCOPE",
         help="search scope for environment stack files",
@@ -188,9 +194,20 @@ def main():
             elif args.out:
                 from envstack.util import dump_yaml
 
-                dump_yaml(file_path=args.out, data=keys)
+                dump_yaml(file_path=args.out, data={"all": keys})
             else:
                 for key, value in keys.items():
+                    print(f"{key}: {value}")
+
+        elif args.set:
+            data = dict(kv.split(":", 1) for kv in args.set)
+
+            if args.out:
+                from envstack.util import dump_yaml
+
+                dump_yaml(file_path=args.out, data={"all": data})
+            else:
+                for key, value in data.items():
                     print(f"{key}: {value}")
 
         elif args.out:

--- a/lib/envstack/cli.py
+++ b/lib/envstack/cli.py
@@ -198,14 +198,13 @@ def main():
                 source.write()
             else:
                 for key, value in data.items():
-                    print(f"{key}: {value}")
+                    print(f"{key}={value}")
 
         elif args.set:
             data = dict(kv.split(":", 1) for kv in args.set)
 
             if args.encrypt:
                 data = encrypt_environ(data)
-
             if args.export:
                 print(export_env_to_shell(data))
             elif args.out:
@@ -214,7 +213,7 @@ def main():
                 source.write()
             else:
                 for key, value in data.items():
-                    print(f"{key}: {value}")
+                    print(f"{key}={value}")
 
         elif args.out:
             bake_environ(

--- a/lib/envstack/cli.py
+++ b/lib/envstack/cli.py
@@ -85,12 +85,25 @@ def parse_args():
         default=[config.DEFAULT_NAMESPACE],
         help="the environment stacks to use (default '%s')" % config.DEFAULT_NAMESPACE,
     )
+    encrypt_group = parser.add_argument_group("encryption options")
+    encrypt_group.add_argument(
+        "-e",
+        "--encrypt",
+        action="store_true",
+        help="encrypt environment values",
+    )
+    encrypt_group.add_argument(
+        "--keygen",
+        action="store_true",
+        help="generate encryption keys",
+    )
+    parser.add_argument_group(encrypt_group)
     bake_group = parser.add_argument_group("bake options")
     bake_group.add_argument(
         "-o",
         "--out",
         metavar="FILENAME",
-        help="write the env stack to a new stack file",
+        help="save the environment to an env file",
     )
     bake_group.add_argument(
         "--depth",
@@ -98,28 +111,19 @@ def parse_args():
         default=0,
         help="depth of environment stack to bake",
     )
-    bake_group.add_argument(
-        "--keygen",
-        action="store_true",
-        help="generate encryption keys",
-    )
-    bake_group.add_argument(
-        "-e",
-        "--encrypt",
-        action="store_true",
-        help="encrypt the baked environment values",
-    )
     parser.add_argument_group(bake_group)
-    parser.add_argument(
+    export_group = parser.add_argument_group("export options")
+    export_group.add_argument(
         "--clear",
         action="store_true",
         help="generate unset commands for %s" % config.SHELL,
     )
-    parser.add_argument(
+    export_group.add_argument(
         "--export",
         action="store_true",
         help="generate export commands for %s" % config.SHELL,
     )
+    parser.add_argument_group(export_group)
     parser.add_argument(
         "-p",
         "--platform",

--- a/lib/envstack/cli.py
+++ b/lib/envstack/cli.py
@@ -40,13 +40,12 @@ import traceback
 from envstack import __version__, config
 from envstack.env import (
     bake_environ,
-    clear,
+    Env,
     encrypt_environ,
     export_env_to_shell,
     export,
     load_environ,
     resolve_environ,
-    Source,
     trace_var,
 )
 from envstack.logger import setup_stream_handler
@@ -195,9 +194,7 @@ def main():
             if args.export:
                 print(export_env_to_shell(data))
             elif args.out:
-                source = Source(args.out)
-                source.data = {"all": data}
-                source.write()
+                Env(data).write(args.out)
             else:
                 for key, value in data.items():
                     print(f"{key}={value}")
@@ -210,9 +207,7 @@ def main():
             if args.export:
                 print(export_env_to_shell(data))
             elif args.out:
-                source = Source(args.out)
-                source.data = {"all": data}
-                source.write()
+                Env(data).write(args.out)
             else:
                 for key, value in data.items():
                     print(f"{key}={value}")
@@ -247,6 +242,8 @@ def main():
                 print(source.path)
 
         elif args.clear:
+            from envstack.env import clear
+
             print(clear(args.namespace, config.SHELL))
 
         elif args.export:

--- a/lib/envstack/env.py
+++ b/lib/envstack/env.py
@@ -710,9 +710,18 @@ def bake_environ(
     return baked_env
 
 
-def encrypt_environ(env: dict, node_class: BaseNode = EncryptedNode):
+def encrypt_environ(
+    env: dict, node_class: BaseNode = EncryptedNode, encrypt: bool = True
+):
     """Encrypts all values in a given environment, returning a new environment.
     Looks for encryption keys in the environment.
+
+    Python:
+
+        >>> env = {"FOO": "bar"}
+        >>> env = envstack.encrypt_environ(env)
+
+    Command line:
 
         $ envstack [STACK] --encrypt
 
@@ -720,6 +729,7 @@ def encrypt_environ(env: dict, node_class: BaseNode = EncryptedNode):
     :param node_class: node class to use for encryption.
         Defaults to EncryptedNode, which looks for encryption keys in the
         environment to determine the encryption method.
+    :param encrypt: pre-encrypt the values.
     :returns: encrypted environment.
     """
     # stores the encrypted environment
@@ -736,7 +746,8 @@ def encrypt_environ(env: dict, node_class: BaseNode = EncryptedNode):
         if type(v) not in custom_node_types:
             # TODO: use to_yaml() method to serialize instead?
             node = node_class(v)
-            node.value = node.encryptor(env=resolved_env).encrypt(str(v))
+            if encrypt:
+                node.value = node.encryptor(env=resolved_env).encrypt(str(v))
             encrypted_env[k] = node
         else:
             encrypted_env[k] = v

--- a/lib/envstack/env.py
+++ b/lib/envstack/env.py
@@ -295,7 +295,11 @@ class Env(dict):
         self.scope = path
 
     def bake(self, filename: str = None, depth: int = 0, encrypt: bool = False):
-        """Bakes the environment into a single environment.
+        """Bakes an environment with multiple sources into a single environment
+        and writes to a new env file.
+
+            >>> env = load_environ(stack_name)
+            >>> env.bake("baked.env")
 
         :param filename: path to save the baked environment.
         :param depth: depth of source files to incldue (default: all).
@@ -345,19 +349,26 @@ class Env(dict):
 
         return baked_env
 
-    def write(self, filename: str = None, encrypt: bool = False):
+    def write(self, filename: str = None):
         """Writes the environment to an env file.
 
             >>> env = Env({"FOO": "${BAR}", "BAR": "bar"})
             >>> env.write("foo.env")
 
-        :param filename: Filename to write the env file.
-        :param encrypt: encrypt the values.
+        To encrypt values, use EncryptedNode:
+
+            >>> env = Env({"FOO": "${BAR}", "BAR": EncryptedNode("bar")})
+            >>> env.write("encrypted.env")
+
+        :param filename: path to save the baked environment.
         :returns: Source object.
         """
+        # the environment was loaded from one or more sources
         if self.sources:
-            baked = self.bake(filename, encrypt=encrypt)
+            baked = self.bake(filename)
             return baked.sources[0]
+
+        # the environment was created from scratch
         else:
             source = Source(filename)
             for k, v in self.items():

--- a/lib/envstack/env.py
+++ b/lib/envstack/env.py
@@ -294,6 +294,21 @@ class Env(dict):
         """
         self.scope = path
 
+    def write(self, path: str = None):
+        """Writes the environment to an env file.
+
+            >>> env = Env({"FOO": "${BAR}", "BAR": "bar"})
+            >>> env.write("foo.env")
+
+        :param path: File path to write the env file.
+        :returns: Source object.
+        """
+        source = Source()
+        for k, v in self.items():
+            source.data[k] = v
+        source.write(path)
+        return source
+
 
 def clear_file_cache():
     """Clears global file cache."""

--- a/lib/envstack/util.py
+++ b/lib/envstack/util.py
@@ -54,7 +54,7 @@ drive_letter_pattern = re.compile(r"(?P<sep>[:;])?(?P<drive>[A-Z]:[/\\])")
 
 # regular expression pattern for bash-like variable expansion
 variable_pattern = re.compile(
-    r"\$\{([a-zA-Z_][a-zA-Z0-9_]*)(?::([=?])((?:\$\{[^}]+\}|[^}])*))?\}"
+    r"\$\{([a-zA-Z_][a-zA-Z0-9_]*)(?::([-=?])((?:\$\{[^}]+\}|[^}])*))?\}"
 )
 
 

--- a/lib/envstack/util.py
+++ b/lib/envstack/util.py
@@ -298,17 +298,20 @@ def evaluate_modifiers(expression: str, environ: dict = os.environ):
         else:
             value = value.replace(varstr, "")
 
-        if operator == "=":
+        # ${VAR:=default} or ${VAR:-default}
+        if operator in ("=", "-"):
             if override:
                 value = override
             elif variable_pattern.search(value) or value is None:
                 value = evaluate_modifiers(argument, environ)
             else:
                 value = value or argument
+        # ${VAR:?error message}
         elif operator == "?":
             if not value:
                 error_message = argument if argument else f"{var_name} is not set"
                 raise ValueError(error_message)
+        # handle recursive references
         elif variable_pattern.search(value):
             value = evaluate_modifiers(value, environ)
         # handle simple ${VAR} substitution

--- a/lib/envstack/util.py
+++ b/lib/envstack/util.py
@@ -560,9 +560,9 @@ def partition_platform_data(data: dict):
     :param data: dictionary to partition.
     :returns: platform partitioned dictionary.
     """
-    # ensure all is present
+    # ensure "all" key is present
     if "all" not in data:
-        data["all"] = {}  # data.copy()
+        data["all"] = dict((k, v) for k, v in data.items() if k != "include")
 
     # platforms of interest (darwin, linux, windows)
     platforms = ["darwin", "linux", "windows"]

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ with open(os.path.join(here, "README.md")) as f:
 
 setup(
     name="envstack",
-    version="0.8.3",
+    version="0.8.4",
     description="Stacked environment variable management system",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/tests/test_cmds.py
+++ b/tests/test_cmds.py
@@ -583,6 +583,7 @@ class TestCommands(unittest.TestCase):
         os.environ["INTERACTIVE"] = "0"
 
     def test_default_echo(self):
+        """Tests the default stack with an echo command."""
         command = "%s -- echo {HELLO}" % self.envstack_bin
         expected_output = "world\n"
         output = subprocess.check_output(
@@ -593,6 +594,7 @@ class TestCommands(unittest.TestCase):
         self.assertEqual(output, expected_output)
 
     def test_default_ls(self):
+        """Tests the default stack with an ls command."""
         command = "%s -- ls" % self.envstack_bin
         expected_output = subprocess.check_output(
             "ls", start_new_session=True, shell=True, universal_newlines=True
@@ -601,6 +603,7 @@ class TestCommands(unittest.TestCase):
         self.assertEqual(output, expected_output)
 
     def test_thing_echo(self):
+        """Tests the thing stack with an echo command."""
         command = "%s thing -- echo {HELLO}" % self.envstack_bin
         expected_output = "goodbye\n"
         output = subprocess.check_output(
@@ -609,6 +612,7 @@ class TestCommands(unittest.TestCase):
         self.assertEqual(output, expected_output)
 
     def test_test_echo_deploy_root(self):
+        """Tests the test stack with an echo command."""
         command = "%s test -- echo {DEPLOY_ROOT}" % self.envstack_bin
         expected_output = f"{self.root}/test\n"
         output = subprocess.check_output(
@@ -617,10 +621,72 @@ class TestCommands(unittest.TestCase):
         self.assertEqual(output, expected_output)
 
     def test_test_echo_deploy_root(self):
+        """Tests the test stack with an echo command."""
         command = "%s test foobar -- echo {DEPLOY_ROOT}" % self.envstack_bin
         expected_output = f"{self.root}/foobar\n"
         output = subprocess.check_output(
             command, start_new_session=True, shell=True, universal_newlines=True
+        )
+        self.assertEqual(output, expected_output)
+
+
+class TestSet(unittest.TestCase):
+    """Tests various envstack set commands."""
+
+    def setUp(self):
+        self.envstack_bin = os.path.join(
+            os.path.dirname(__file__), "..", "bin", "envstack"
+        )
+        envpath = os.path.join(os.path.dirname(__file__), "..", "env")
+        self.root = {
+            "linux": "/mnt/pipe",
+            "win32": "X:/pipe",
+            "darwin": "/Volumes/pipe",
+        }.get(sys.platform)
+        os.environ["ENVPATH"] = envpath
+        os.environ["INTERACTIVE"] = "0"
+
+    def test_hello_world(self):
+        """Tests setting HELLO to world."""
+        command = "%s --set HELLO:world" % self.envstack_bin
+        expected_output = "HELLO=world\n"
+        output = subprocess.check_output(
+            command,
+            shell=True,
+            universal_newlines=True,
+        )
+        self.assertEqual(output, expected_output)
+
+    def test_hello_world_encrypted(self):
+        """Tests setting HELLO to world encrypted."""
+        command = "%s --set HELLO:world --encrypt" % self.envstack_bin
+        expected_output = "HELLO=d29ybGQ=\n"
+        output = subprocess.check_output(
+            command,
+            shell=True,
+            universal_newlines=True,
+        )
+        self.assertEqual(output, expected_output)
+
+    def test_foo_bar(self):
+        """Tests setting FOO and BAR."""
+        command = r"%s --set FOO:foo BAR:\${FOO}" % self.envstack_bin
+        expected_output = "FOO=foo\nBAR=${FOO}\n"
+        output = subprocess.check_output(
+            command,
+            shell=True,
+            universal_newlines=True,
+        )
+        self.assertEqual(output, expected_output)
+
+    def test_foo_bar_encrypted(self):
+        """Tests setting FOO and BAR encrypted."""
+        command = r"%s --set FOO:foo BAR:\${FOO} --encrypt" % self.envstack_bin
+        expected_output = "FOO=Zm9v\nBAR=JHtGT099\n"
+        output = subprocess.check_output(
+            command,
+            shell=True,
+            universal_newlines=True,
         )
         self.assertEqual(output, expected_output)
 

--- a/tests/test_cmds.py
+++ b/tests/test_cmds.py
@@ -675,7 +675,7 @@ class TestSet(unittest.TestCase):
 
     def test_foo_bar(self):
         """Tests setting FOO and BAR."""
-        command = r"%s --set FOO:foo BAR:\${FOO}" % self.envstack_bin
+        command = r"%s -s FOO:foo BAR:\${FOO}" % self.envstack_bin
         expected_output = "FOO=foo\nBAR=${FOO}\n"
         output = subprocess.check_output(
             command,
@@ -686,7 +686,7 @@ class TestSet(unittest.TestCase):
 
     def test_foo_bar_encrypted(self):
         """Tests setting FOO and BAR encrypted."""
-        command = r"%s --set FOO:foo BAR:\${FOO} --encrypt" % self.envstack_bin
+        command = r"%s -s FOO:foo BAR:\${FOO} --encrypt" % self.envstack_bin
         expected_output = "FOO=Zm9v\nBAR=JHtGT099\n"
         output = subprocess.check_output(
             command,
@@ -724,7 +724,7 @@ windows:
 
     def test_foo_bar_bake_encrypted(self):
         """Tests setting FOO and BAR and bake it out to a file with encrypted values."""
-        command = r"%s --set FOO:foo BAR:\${FOO} --encrypt -o %s; cat %s" % (
+        command = r"%s --set FOO:foo BAR:\${FOO} -eo %s; cat %s" % (
             self.envstack_bin,
             self.filename,
             self.filename,

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -120,30 +120,51 @@ class TestEnvVar(unittest.TestCase):
 
 
 class TestEnv(unittest.TestCase):
+    def setUp(self):
+        self.filename = "testenv.env"
+
+    def tearDown(self):
+        if os.path.exists(self.filename):
+            os.remove(self.filename)
+
     def test_getitem(self):
+        """Tests getting an item from the environment."""
         env = Env({"FOO": "foo", "BAR": "$FOO"})
         self.assertEqual(env["BAR"], "$FOO")
 
     def test_get(self):
+        """Tests getting a value from the environment."""
         env = Env({"FOO": "foo", "BAR": "$FOO"})
         self.assertEqual(env.get("BAR"), "$FOO")
         self.assertEqual(env.get("BAZ"), None)
         self.assertEqual(env.get("BAZ", "default"), "default")
 
     def test_copy(self):
+        """Tests copying an environment."""
         env = Env({"FOO": "foo", "BAR": "$FOO"})
         copied = env.copy()
         self.assertEqual(copied, {"FOO": "foo", "BAR": "$FOO"})
 
     def test_set_namespace(self):
+        """Tests setting the namespace of the environment."""
         env = Env()
         env.set_namespace("test")
         self.assertEqual(env.namespace, "test")
 
     def test_set_scope(self):
+        """Tests setting the scope of the environment."""
         env = Env()
         env.set_scope("/path/to/scope")
         self.assertEqual(env.scope, "/path/to/scope")
+
+    def test_write(self):
+        """Tests writing an environment to a file."""
+        from envstack.env import load_environ
+        env1 = Env({"FOO": "foo", "BAR": "${FOO}"})
+        env1.write(self.filename)
+        env2 = load_environ(self.filename)
+        self.assertEqual(env1["FOO"], env2["FOO"])
+        self.assertEqual(env1["BAR"], env2["BAR"])
 
 
 class TestScope(unittest.TestCase):

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -129,6 +129,11 @@ class TestEnv(unittest.TestCase):
             "darwin": "/Volumes/pipe",
         }.get(sys.platform)
         os.environ["ENVPATH"] = envpath
+        # remove so we use base64 encoding by default
+        if AESGCMEncryptor.KEY_VAR_NAME in os.environ:
+            del os.environ[AESGCMEncryptor.KEY_VAR_NAME]
+        if FernetEncryptor.KEY_VAR_NAME in os.environ:
+            del os.environ[FernetEncryptor.KEY_VAR_NAME]
 
     def tearDown(self):
         if os.path.exists(self.filename):

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -407,6 +407,14 @@ class TestResolveEnviron(unittest.TestCase):
         resolved = resolve_environ(env)
         self.assertEqual(resolved["VAR"], "/foo/bar")
 
+    def test_expansion_modifier_alt(self):
+        """Tests var with an expansion modifier using alt modifier."""
+        from envstack.env import resolve_environ
+
+        env = {"VAR": "${VAR:-/foo/bar}"}
+        resolved = resolve_environ(env)
+        self.assertEqual(resolved["VAR"], "/foo/bar")
+
     def test_expansion_modifier_nested_undefined(self):
         """Tests expansion modifier with no value."""
         from envstack.env import resolve_environ

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -617,13 +617,13 @@ class TestBakeEnviron(unittest.TestCase):
         # make sure environment sources are different
         if stack_name == "doesnotexist":
             self.assertEqual(env.sources, [])
-            # self.assertEqual(baked.sources, [])
+            self.assertEqual(len(baked.sources), 1)
         elif stack_name == "default":
             self.assertTrue(len(env.sources[0].includes()) == 0)
         else:
             self.assertNotEqual(env.sources, baked.sources)
             self.assertTrue(len(env.sources) > 0)
-            # self.assertEqual(baked.sources, [])
+            self.assertEqual(len(baked.sources), 1)
             self.assertTrue(len(env) > 0)
             self.assertTrue(len(baked) > 0)
 
@@ -649,7 +649,7 @@ class TestBakeEnviron(unittest.TestCase):
         # make sure environment sources are different
         if stack_name == "doesnotexist":
             self.assertEqual(env.sources, [])
-            # self.assertEqual(baked2.sources, [])
+            self.assertEqual(len(baked.sources), 1)
         else:
             self.assertNotEqual(baked2.sources, baked2_reloaded.sources)
             self.assertTrue(len(baked2) > 0)

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -752,6 +752,36 @@ class TestEncryptEnviron(unittest.TestCase):
         """Tests encrypting the thing environment."""
         self.run_tests("thing")
 
+    def test_encrypt_environ_as_env(self):
+        """Tests encrypting an environment as Env."""
+        from envstack.env import encrypt_environ
+        from envstack.node import EncryptedNode
+
+        env = Env({"HELLO": "world", "FOO": "foo", "BAR": "${FOO}"})
+        encrypted = encrypt_environ(env)
+        self.assertNotEqual(encrypted["HELLO"], "d29ybGQ=")
+        self.assertTrue(isinstance(encrypted["HELLO"], EncryptedNode))
+        self.assertEqual(encrypted["HELLO"].resolve(env=env), "world")
+        self.assertNotEqual(encrypted["FOO"], env["FOO"])
+        self.assertEqual(encrypted["FOO"].resolve(env=env), env["FOO"])
+        self.assertNotEqual(encrypted["BAR"], env["BAR"])
+        self.assertEqual(encrypted["BAR"].resolve(env=env), env["BAR"])
+
+    def test_encrypt_environ_as_dict(self):
+        """Tests encrypting an environment as dict."""
+        from envstack.env import encrypt_environ
+        from envstack.node import EncryptedNode
+
+        env = {"HELLO": "world", "FOO": "foo", "BAR": "${FOO}"}
+        encrypted = encrypt_environ(env)
+        self.assertNotEqual(encrypted["HELLO"], "d29ybGQ=")
+        self.assertTrue(isinstance(encrypted["HELLO"], EncryptedNode))
+        self.assertEqual(encrypted["HELLO"].resolve(env=env), "world")
+        self.assertNotEqual(encrypted["FOO"], env["FOO"])
+        self.assertEqual(encrypted["FOO"].resolve(env=env), env["FOO"])
+        self.assertNotEqual(encrypted["BAR"], env["BAR"])
+        self.assertEqual(encrypted["BAR"].resolve(env=env), env["BAR"])
+
 
 class TestIssues(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Version 0.8.4 RC

- adds -s/--set command option for setting values
- adds -e short option for --encrypt
- adds Env write and bake methods
- fixes --keygen output when writing to a file
- resolves issue #25 
- fixes support for :- modifier
- bumps version to 0.8.4

```python
>>> env = Env({"FOO": "${BAR}", "BAR": "bar"})
>>> env.write("foo.env")
```

To create a new foo.env file with FOO:bar with encrypted values:

```shell
$ envstack -s FOO:bar -eo foo.env
```