### PR TITLE
Version 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.0.1] - 2026-02-08
+
+### Fixed
+- SyntaxWarning: invalid escape sequence in envstack shell
+
+---
+
 ## [1.0.0] - 2026-02-08
 
 ### Added

--- a/lib/envstack/__init__.py
+++ b/lib/envstack/__init__.py
@@ -34,7 +34,7 @@ Stacked environment variable management system.
 """
 
 __prog__ = "envstack"
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 
 from envstack.env import clear, init, revert, save  # noqa: F401
 from envstack.env import load_environ, resolve_environ  # noqa: F401

--- a/lib/envstack/envshell.py
+++ b/lib/envstack/envshell.py
@@ -131,7 +131,7 @@ class EnvshellWrapper(Wrapper):
         if os.name == "nt":
             return ("PROMPT", "$E[32m(${ENV:=${STACK}})$E[0m $P$G ")
         else:
-            return ("PS1", "\[\e[32m\](${ENV:=${STACK}})\[\e[0m\] \w\$ ")
+            return ("PS1", r"\[\e[32m\](${ENV:=${STACK}})\[\e[0m\] \w\$ ")
 
     def get_subprocess_env(self):
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "envstack"
-version = "1.0.0"
+version = "1.0.1"
 description = "Environment variable composition layer for tools and processes."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.6"


### PR DESCRIPTION
This pull request releases version 1.0.1 of `envstack`, addressing a syntax warning in the shell prompt code and updating version information throughout the project.

Bug fix:

* Fixed a `SyntaxWarning` caused by an invalid escape sequence in the shell prompt string by using a raw string in the `get_shell_prompt` method in `lib/envstack/envshell.py`.

Version updates:

* Updated the version number to `1.0.1` in `lib/envstack/__init__.py`, `pyproject.toml`, and added a new entry to the `CHANGELOG.md` reflecting the bug fix. [[1]](diffhunk://#diff-19a400995e4b3931b24ecbc985b0b893032814338598e09e883e5711ff22a911L37-R37) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R7) [[3]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R16)