### PR TITLE
Version 1.0.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,11 +8,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: ${{ matrix.python-version }}
       - run: python -m pip install --upgrade pip
       - run: pip install pytest
       - run: pip install -e .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.0.2] - 2026-04-01
+
+### Changed
+- add a `make pytest` target that installs the package in editable mode before running the test suite
+
+### Fixed
+- remove `return` statements from `finally` blocks in encryption helpers to avoid newer Python `SyntaxWarning`s
+- harden optional `cryptography` imports so missing crypto dependencies do not break exception handling paths
+
+---
+
 ## [1.0.1] - 2026-02-08
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.2] - 2026-04-01
 
 ### Changed
-- add a `make pytest` target that installs the package in editable mode before running the test suite
+- add a self-contained `make test` target that installs `pytest` and the package in editable mode before running the test suite
+- mark `all` as a phony Make target to avoid filename collisions
 
 ### Fixed
 - remove `return` statements from `finally` blocks in encryption helpers to avoid newer Python `SyntaxWarning`s
-- harden optional `cryptography` imports so missing crypto dependencies do not break exception handling paths
+- harden optional `cryptography` imports with a decorator-based availability guard so missing crypto dependencies raise a clear runtime error instead of `NoneType` failures
 
 ---
 

--- a/Makefile
+++ b/Makefile
@@ -36,13 +36,9 @@ build: clean
 # Combined target to build for both platforms
 all: build
 
-# Test target to verify the build
-test:
-	$(ENVSTACK_CMD) -- ls -al
-	${ENVSTACK_CMD} -- which python
-
 # Run the pytest suite from an editable install, matching CI behavior
-pytest:
+test:
+	python -m pip install pytest
 	python -m pip install -e .
 	pytest tests -q
 
@@ -56,4 +52,4 @@ install: build
 	dist --force --yes
 
 # Phony targets
-.PHONY: build dryrun install clean test pytest
+.PHONY: all build dryrun install clean test pytest

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,11 @@ test:
 	$(ENVSTACK_CMD) -- ls -al
 	${ENVSTACK_CMD} -- which python
 
+# Run the pytest suite from an editable install, matching CI behavior
+pytest:
+	python -m pip install -e .
+	pytest tests -q
+
 # Install dryrun target to simulate installation
 dryrun:
 	$(ENVSTACK_CMD) -- dist --dryrun
@@ -51,4 +56,4 @@ install: build
 	dist --force --yes
 
 # Phony targets
-.PHONY: build dryrun install clean
+.PHONY: build dryrun install clean test pytest

--- a/lib/envstack/__init__.py
+++ b/lib/envstack/__init__.py
@@ -34,7 +34,7 @@ Stacked environment variable management system.
 """
 
 __prog__ = "envstack"
-__version__ = "1.0.1"
+__version__ = "1.0.2"
 
 from envstack.env import clear, init, revert, save  # noqa: F401
 from envstack.env import load_environ, resolve_environ  # noqa: F401

--- a/lib/envstack/encrypt.py
+++ b/lib/envstack/encrypt.py
@@ -44,9 +44,15 @@ from envstack.logger import log
 # cryptography and _rust dependency may not be available everywhere
 # ImportError: DLL load failed while importing _rust: Module not found.
 Fernet = None
+InvalidToken = type("InvalidToken", (Exception,), {})
+InvalidTag = type("InvalidTag", (Exception,), {})
+padding = None
+Cipher = None
+algorithms = None
+modes = None
 try:
-    import cryptography.exceptions
     from cryptography.fernet import Fernet, InvalidToken
+    from cryptography.exceptions import InvalidTag
     from cryptography.hazmat.primitives import padding
     from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 except ImportError as err:
@@ -217,7 +223,7 @@ class AESGCMEncryptor(object):
             results = compact_store(encrypted_data)
         except binascii.Error as e:
             log.error("invalid base64 encoding: %s", e)
-        except cryptography.exceptions.InvalidTag:
+        except InvalidTag:
             log.error("invalid encryption key")
         except ValueError as e:
             log.error("invalid value: %s", e)
@@ -237,7 +243,7 @@ class AESGCMEncryptor(object):
             return decrypted.decode()
         except binascii.Error as e:
             log.debug("invalid base64 encoding: %s", e)
-        except cryptography.exceptions.InvalidTag:
+        except InvalidTag:
             log.debug("invalid encryption key")
         except ValueError as e:
             log.debug("invalid value: %s", e)

--- a/lib/envstack/encrypt.py
+++ b/lib/envstack/encrypt.py
@@ -121,8 +121,7 @@ class FernetEncryptor(object):
             log.error("invalid value: %s", e)
         except Exception as e:
             log.error("unhandled error: %s", e)
-        finally:
-            return results
+        return results
 
     def decrypt(self, data: str):
         """Decrypt a secret using Fernet.
@@ -224,8 +223,7 @@ class AESGCMEncryptor(object):
             log.error("invalid value: %s", e)
         except Exception as e:
             log.error("unhandled error: %s", e)
-        finally:
-            return results
+        return results
 
     def decrypt(self, data: str):
         """Convenience function to decrypt a secret using AES-GCM.

--- a/lib/envstack/encrypt.py
+++ b/lib/envstack/encrypt.py
@@ -38,11 +38,13 @@ import binascii
 import os
 import secrets
 from base64 import b64decode, b64encode
+from functools import wraps
 
 from envstack.logger import log
 
 # cryptography and _rust dependency may not be available everywhere
 # ImportError: DLL load failed while importing _rust: Module not found.
+CRYPTOGRAPHY_AVAILABLE = False
 Fernet = None
 InvalidToken = type("InvalidToken", (Exception,), {})
 InvalidTag = type("InvalidTag", (Exception,), {})
@@ -55,8 +57,21 @@ try:
     from cryptography.exceptions import InvalidTag
     from cryptography.hazmat.primitives import padding
     from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+    CRYPTOGRAPHY_AVAILABLE = True
 except ImportError as err:
     log.debug("cryptography module not available: %s", err)
+
+
+def require_cryptography(func):
+    """Guard crypto-backed functions when cryptography is unavailable."""
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        if not CRYPTOGRAPHY_AVAILABLE:
+            raise RuntimeError("cryptography support is not available")
+        return func(*args, **kwargs)
+
+    return wrapper
 
 
 class Base64Encryptor(object):
@@ -90,6 +105,7 @@ class FernetEncryptor(object):
             self.key = self.get_key(env)
 
     @classmethod
+    @require_cryptography
     def generate_key(csl):
         """Generate a new 256-bit encryption key."""
         if Fernet:
@@ -110,6 +126,7 @@ class FernetEncryptor(object):
             return Fernet(key)
         return key
 
+    @require_cryptography
     def encrypt(self, data: str):
         """Encrypt a secret using Fernet.
 
@@ -129,6 +146,7 @@ class FernetEncryptor(object):
             log.error("unhandled error: %s", e)
         return results
 
+    @require_cryptography
     def decrypt(self, data: str):
         """Decrypt a secret using Fernet.
 
@@ -158,6 +176,7 @@ class AESGCMEncryptor(object):
             self.key = self.get_key(env)
 
     @classmethod
+    @require_cryptography
     def generate_key(csl):
         """Generate a new 256-bit encryption key."""
         key = secrets.token_bytes(32)
@@ -176,6 +195,7 @@ class AESGCMEncryptor(object):
                 raise ValueError("invalid base64 encoding: %s" % e)
         return key
 
+    @require_cryptography
     def encrypt_data(self, secret: str):
         """Encrypt a secret using AES-GCM.
 
@@ -194,6 +214,7 @@ class AESGCMEncryptor(object):
             "tag": b64encode(encryptor.tag).decode(),
         }
 
+    @require_cryptography
     def decrypt_data(self, encrypted_data: dict):
         """Decrypt a secret using AES-GCM.
 
@@ -252,6 +273,7 @@ class AESGCMEncryptor(object):
         return data
 
 
+@require_cryptography
 def pad_data(data: str):
     """Pad data to be block-aligned for AES encryption.
 
@@ -262,6 +284,7 @@ def pad_data(data: str):
     return padder.update(str(data).encode()) + padder.finalize()
 
 
+@require_cryptography
 def unpad_data(data: dict):
     """Unpad data after decryption.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "envstack"
-version = "1.0.1"
+version = "1.0.2"
 description = "Environment variable composition layer for tools and processes."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.6"

--- a/tests/fixtures/env/test.env
+++ b/tests/fixtures/env/test.env
@@ -1,7 +1,7 @@
 #!/usr/bin/env envstack
 include: [default]
 all: &all
-  PYVERSION: $(python -c "import sys; print(f'{sys.version_info[0]}.{sys.version_info[1]}')")
+  PYVERSION: $(python -c "import sys; print(repr(f'{sys.version_info[0]}.{sys.version_info[1]}'))")
   PYTHONPATH: ${DEPLOY_ROOT}/lib/python${PYVERSION}
 darwin:
   <<: *all


### PR DESCRIPTION
This pull request updates the project to version 1.0.2, focusing on improving the test workflow and hardening the encryption helpers. The main improvements include adding a new Makefile target for running tests in editable mode, updating the handling of optional cryptography dependencies to prevent errors, and removing problematic `return` statements from `finally` blocks to avoid Python warnings.

**Test workflow improvements:**
* Added a `pytest` target to the `Makefile` that installs the package in editable mode before running the test suite, matching CI behavior.
* Updated the `.PHONY` targets in the `Makefile` to include `pytest`.

**Encryption helper fixes and hardening:**
* Removed `return` statements from `finally` blocks in encryption helpers to avoid newer Python `SyntaxWarning`s. [[1]](diffhunk://#diff-15f6cc77fdab0ecc42b6789db27b45c3920c0f02b5157d0f0772016bc7dc1603L124) [[2]](diffhunk://#diff-15f6cc77fdab0ecc42b6789db27b45c3920c0f02b5157d0f0772016bc7dc1603L221-L227)
* Improved optional `cryptography` imports by defining fallback classes and variables so missing crypto dependencies do not break exception handling paths. Updated exception handling to use these fallbacks. [[1]](diffhunk://#diff-15f6cc77fdab0ecc42b6789db27b45c3920c0f02b5157d0f0772016bc7dc1603R47-R55) [[2]](diffhunk://#diff-15f6cc77fdab0ecc42b6789db27b45c3920c0f02b5157d0f0772016bc7dc1603L221-L227) [[3]](diffhunk://#diff-15f6cc77fdab0ecc42b6789db27b45c3920c0f02b5157d0f0772016bc7dc1603L242-R246)

**Version bump:**
* Bumped the project version to 1.0.2 in both `pyproject.toml` and `lib/envstack/__init__.py`. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R7) [[2]](diffhunk://#diff-19a400995e4b3931b24ecbc985b0b893032814338598e09e883e5711ff22a911L37-R37)

**Changelog update:**
* Updated `CHANGELOG.md` to document the new version and its changes.